### PR TITLE
feat: inventory management + dynamic spread for profit market making

### DIFF
--- a/src/main/java/io/arbitrix/core/strategy/profit_market_making/filter/TrendFilter.java
+++ b/src/main/java/io/arbitrix/core/strategy/profit_market_making/filter/TrendFilter.java
@@ -1,0 +1,117 @@
+package io.arbitrix.core.strategy.profit_market_making.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import io.arbitrix.core.strategy.base.condition.ExecuteStrategyConditional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayDeque;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 行情趋势过滤器：检测单边趋势行情，暂停做市以避免逆向选择损失。
+ *
+ * <p>检测逻辑：
+ * <ol>
+ *   <li>维护最近 {@link #PRICE_WINDOW} 个 tick 的价格队列</li>
+ *   <li>比较当前价格与窗口最旧价格的涨跌幅</li>
+ *   <li>涨跌幅绝对值超过 {@link #TREND_THRESHOLD} → 判定为趋势行情</li>
+ *   <li>触发后冻结 {@link #PAUSE_TICKS} 个 tick，冻结期内不做市</li>
+ *   <li>冻结期结束后自动恢复，等待下一次判断</li>
+ * </ol>
+ *
+ * <p>参数说明（1万U做市场景）：
+ * <ul>
+ *   <li>PRICE_WINDOW = 20：观测最近20个tick，约1~2秒</li>
+ *   <li>TREND_THRESHOLD = 0.0015：单方向移动0.15%触发暂停</li>
+ *   <li>PAUSE_TICKS = 15：暂停15个tick后恢复观测</li>
+ * </ul>
+ *
+ * @author 3-X
+ */
+@Slf4j
+@Component
+@ExecuteStrategyConditional(executeStrategyName = "profit_market_making")
+public class TrendFilter {
+
+    /** 价格观测窗口大小（tick 数） */
+    private static final int PRICE_WINDOW = 20;
+
+    /** 触发暂停的单向移动阈值（0.15%） */
+    private static final BigDecimal TREND_THRESHOLD = new BigDecimal("0.0015");
+
+    /** 触发趋势后暂停的 tick 数 */
+    private static final int PAUSE_TICKS = 15;
+
+    private final ConcurrentHashMap<String, SymbolState> stateMap = new ConcurrentHashMap<>();
+
+    /**
+     * 更新价格并判断是否处于趋势行情。
+     *
+     * <p>此方法每个 tick 调用一次，同时完成更新与检测。
+     *
+     * @param symbol       交易对
+     * @param currentPrice 当前 mid price（bid/ask 均可）
+     * @return {@code true} = 趋势行情中，暂停做市；{@code false} = 正常，可以挂单
+     */
+    public boolean isTrending(String symbol, BigDecimal currentPrice) {
+        SymbolState state = stateMap.computeIfAbsent(symbol, k -> new SymbolState());
+        return state.update(currentPrice);
+    }
+
+    /** 查询当前暂停状态（不更新价格） */
+    public boolean isPaused(String symbol) {
+        SymbolState state = stateMap.get(symbol);
+        return state != null && state.pauseCountdown.get() > 0;
+    }
+
+    // ── 内部状态 ────────────────────────────────────────────────────────
+
+    private static class SymbolState {
+        private final ArrayDeque<BigDecimal> priceWindow = new ArrayDeque<>(PRICE_WINDOW);
+        /** 剩余暂停 tick 数，0 表示未暂停 */
+        private final AtomicInteger pauseCountdown = new AtomicInteger(0);
+
+        /**
+         * 更新价格，返回是否处于暂停状态。
+         */
+        boolean update(BigDecimal price) {
+            // 冻结期倒计时
+            int remaining = pauseCountdown.get();
+            if (remaining > 0) {
+                pauseCountdown.decrementAndGet();
+                return true;
+            }
+
+            // 维护价格窗口
+            if (priceWindow.size() >= PRICE_WINDOW) {
+                priceWindow.pollFirst();
+            }
+            priceWindow.addLast(price);
+
+            // 窗口不足时不做判断
+            if (priceWindow.size() < PRICE_WINDOW) {
+                return false;
+            }
+
+            BigDecimal oldest = priceWindow.peekFirst();
+            if (oldest == null || oldest.compareTo(BigDecimal.ZERO) == 0) {
+                return false;
+            }
+
+            // 计算窗口内涨跌幅
+            BigDecimal change = price.subtract(oldest)
+                    .divide(oldest, 8, RoundingMode.HALF_UP)
+                    .abs();
+
+            if (change.compareTo(TREND_THRESHOLD) >= 0) {
+                pauseCountdown.set(PAUSE_TICKS);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/arbitrix/core/strategy/profit_market_making/inventory/DynamicSpreadCalculator.java
+++ b/src/main/java/io/arbitrix/core/strategy/profit_market_making/inventory/DynamicSpreadCalculator.java
@@ -1,0 +1,150 @@
+package io.arbitrix.core.strategy.profit_market_making.inventory;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import io.arbitrix.core.strategy.base.condition.ExecuteStrategyConditional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayDeque;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 动态价差计算器：根据最近价格波动率，实时调整做市价差倍数。
+ *
+ * <p>逻辑：
+ * <ul>
+ *   <li>使用滑动窗口维护最近 N 次价格，计算收益率标准差（即波动率）</li>
+ *   <li>当波动率高于基准时，价差倍数增大（最大 {@link #MAX_VOLATILITY_MULTIPLIER}）</li>
+ *   <li>当波动率低于基准时，价差维持基础值（倍数=1）</li>
+ * </ul>
+ *
+ * @author 3-X
+ */
+@Slf4j
+@Component
+@ExecuteStrategyConditional(executeStrategyName = "profit_market_making")
+public class DynamicSpreadCalculator {
+
+    /**
+     * 波动率计算窗口大小
+     */
+    private static final int VOLATILITY_WINDOW = 100;
+
+    /**
+     * 基准波动率：低于此值不放宽价差（约 0.05%/tick）
+     */
+    private static final double BASELINE_VOLATILITY = 0.0005;
+
+    /**
+     * 波动率最大价差倍数（波动率极高时最多放宽到 2 倍）
+     */
+    private static final BigDecimal MAX_VOLATILITY_MULTIPLIER = new BigDecimal("2.0");
+
+    // symbol -> 价格滑动窗口（使用 Welford 在线算法）
+    private final ConcurrentHashMap<String, VolatilityState> stateMap = new ConcurrentHashMap<>();
+
+    /**
+     * 每次收到新价格时更新波动率状态
+     *
+     * @param symbol   交易对
+     * @param midPrice 当前中间价
+     */
+    public void updatePrice(String symbol, BigDecimal midPrice) {
+        stateMap.compute(symbol, (k, state) -> {
+            if (state == null) state = new VolatilityState();
+            state.addPrice(midPrice.doubleValue());
+            return state;
+        });
+    }
+
+    /**
+     * 获取当前波动率调整倍数。
+     *
+     * @param symbol 交易对
+     * @return 价差倍数（1.0 ~ MAX_VOLATILITY_MULTIPLIER）
+     */
+    public BigDecimal getVolatilityMultiplier(String symbol) {
+        VolatilityState state = stateMap.get(symbol);
+        if (state == null || state.count < 10) {
+            return BigDecimal.ONE;  // 数据不足，不调整
+        }
+
+        double volatility = state.getVolatility();
+        if (volatility <= BASELINE_VOLATILITY) {
+            return BigDecimal.ONE;
+        }
+
+        // 将波动率线性映射到 [1.0, MAX]
+        // multiplier = 1 + (volatility / BASELINE - 1) * (MAX - 1)，上限 MAX
+        double ratio = Math.min(volatility / BASELINE_VOLATILITY, 3.0);  // 超过3倍基准波动率就封顶
+        double multiplier = 1.0 + (ratio - 1.0) / 2.0 * (MAX_VOLATILITY_MULTIPLIER.doubleValue() - 1.0);
+        multiplier = Math.min(multiplier, MAX_VOLATILITY_MULTIPLIER.doubleValue());
+
+        BigDecimal result = BigDecimal.valueOf(multiplier).setScale(4, RoundingMode.HALF_UP);
+        log.debug("DynamicSpreadCalculator.getVolatilityMultiplier: symbol={}, volatility={}, multiplier={}",
+                symbol, volatility, result);
+        return result;
+    }
+
+    /**
+     * 使用 Welford 在线算法 + 固定大小滑动窗口维护价格收益率统计量。
+     */
+    private static class VolatilityState {
+        private final ArrayDeque<Double> returns = new ArrayDeque<>(VOLATILITY_WINDOW);
+        private double lastPrice = 0;
+        private int count = 0;
+
+        // Welford 统计量（针对收益率序列）
+        private double runningMean = 0;
+        private double runningM2 = 0;
+        private int welfordCount = 0;
+
+        void addPrice(double price) {
+            if (lastPrice == 0) {
+                lastPrice = price;
+                return;
+            }
+
+            // 计算对数收益率
+            double ret = Math.log(price / lastPrice);
+            lastPrice = price;
+            count++;
+
+            // 滑动窗口：移除最旧的收益率
+            if (returns.size() >= VOLATILITY_WINDOW) {
+                double oldest = returns.pollFirst();
+                removeFromWelford(oldest);
+            }
+
+            returns.addLast(ret);
+            addToWelford(ret);
+        }
+
+        double getVolatility() {
+            if (welfordCount < 2) return 0;
+            return Math.sqrt(runningM2 / (welfordCount - 1));
+        }
+
+        private void addToWelford(double value) {
+            welfordCount++;
+            double delta = value - runningMean;
+            runningMean += delta / welfordCount;
+            runningM2 += delta * (value - runningMean);
+        }
+
+        private void removeFromWelford(double value) {
+            if (welfordCount <= 1) {
+                welfordCount = 0;
+                runningMean = 0;
+                runningM2 = 0;
+                return;
+            }
+            double oldMean = runningMean;
+            runningMean = (runningMean * welfordCount - value) / (welfordCount - 1);
+            runningM2 -= (value - oldMean) * (value - runningMean);
+            runningM2 = Math.max(runningM2, 0.0);
+            welfordCount--;
+        }
+    }
+}

--- a/src/main/java/io/arbitrix/core/strategy/profit_market_making/inventory/InventoryTracker.java
+++ b/src/main/java/io/arbitrix/core/strategy/profit_market_making/inventory/InventoryTracker.java
@@ -1,0 +1,126 @@
+package io.arbitrix.core.strategy.profit_market_making.inventory;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import io.arbitrix.core.common.enums.OrderSide;
+import io.arbitrix.core.strategy.base.condition.ExecuteStrategyConditional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 库存跟踪器：跟踪每个交易对的 base coin 净持仓（以 USDT 等值估算）。
+ *
+ * <p>仓位偏斜（skew）定义：
+ * <ul>
+ *   <li>正值（> 0）：多头偏斜，base coin 过多，应收窄卖单价差、放宽买单价差</li>
+ *   <li>负值（< 0）：空头偏斜，base coin 过少，应收窄买单价差、放宽卖单价差</li>
+ *   <li>0：平衡，使用基础价差</li>
+ * </ul>
+ *
+ * @author 3-X
+ */
+@Slf4j
+@Component
+@ExecuteStrategyConditional(executeStrategyName = "profit_market_making")
+public class InventoryTracker {
+
+    /**
+     * 目标仓位比例：base coin 占总资产的 50%
+     */
+    private static final BigDecimal TARGET_RATIO = new BigDecimal("0.5");
+
+    /**
+     * 仓位偏斜阈值：超过 ±20% 触发调整
+     */
+    private static final BigDecimal SKEW_THRESHOLD = new BigDecimal("0.2");
+
+    /**
+     * 最大偏斜因子：最多将价差放宽/收窄到 2 倍
+     */
+    private static final BigDecimal MAX_SKEW_FACTOR = new BigDecimal("1.5");
+
+    /**
+     * symbol -> base coin 净持仓数量（正数 = 多头）
+     */
+    private final ConcurrentHashMap<String, BigDecimal> inventory = new ConcurrentHashMap<>();
+
+    /**
+     * 订单成交时更新持仓
+     *
+     * @param symbol   交易对（如 ETHUSDT）
+     * @param side     方向
+     * @param quantity 成交数量（base coin）
+     */
+    public void onOrderFilled(String symbol, OrderSide side, BigDecimal quantity) {
+        BigDecimal delta = OrderSide.BUY.equals(side) ? quantity : quantity.negate();
+        inventory.merge(symbol, delta, BigDecimal::add);
+        log.debug("InventoryTracker.onOrderFilled: symbol={}, side={}, qty={}, newInventory={}",
+                symbol, side, quantity, inventory.get(symbol));
+    }
+
+    /**
+     * 计算库存偏斜调整因子，用于修正买卖单价差。
+     *
+     * <p>返回值含义：
+     * <ul>
+     *   <li>{@code buyFactor}：买单价差乘数（> 1 放宽，< 1 收窄）</li>
+     *   <li>{@code sellFactor}：卖单价差乘数（> 1 放宽，< 1 收窄）</li>
+     * </ul>
+     *
+     * @param symbol      交易对
+     * @param midPrice    当前中间价
+     * @param totalCapital 总资本（USDT）
+     * @return 买卖因子对 [buyFactor, sellFactor]
+     */
+    public BigDecimal[] getSpreadFactors(String symbol, BigDecimal midPrice, BigDecimal totalCapital) {
+        BigDecimal baseHolding = inventory.getOrDefault(symbol, BigDecimal.ZERO);
+        if (baseHolding.compareTo(BigDecimal.ZERO) == 0 || midPrice.compareTo(BigDecimal.ZERO) == 0) {
+            return new BigDecimal[]{BigDecimal.ONE, BigDecimal.ONE};
+        }
+
+        // base coin 持仓折算为 USDT
+        BigDecimal baseValueUsdt = baseHolding.multiply(midPrice);
+
+        // 当前 base 占比 = base USDT / 总资本
+        BigDecimal currentRatio = baseValueUsdt.divide(totalCapital, 8, RoundingMode.HALF_UP);
+
+        // 偏斜量 = 当前占比 - 目标占比（0.5）
+        BigDecimal skew = currentRatio.subtract(TARGET_RATIO);
+
+        // 偏斜未超过阈值，不调整
+        if (skew.abs().compareTo(SKEW_THRESHOLD) < 0) {
+            return new BigDecimal[]{BigDecimal.ONE, BigDecimal.ONE};
+        }
+
+        // 将偏斜映射到 [1.0, MAX_SKEW_FACTOR] 范围
+        // 偏斜程度（0 ~ 1）= (|skew| - threshold) / (0.5 - threshold)
+        BigDecimal skewDegree = skew.abs().subtract(SKEW_THRESHOLD)
+                .divide(new BigDecimal("0.5").subtract(SKEW_THRESHOLD), 8, RoundingMode.HALF_UP)
+                .min(BigDecimal.ONE);  // 上限1
+        BigDecimal adjustment = BigDecimal.ONE.add(skewDegree.multiply(MAX_SKEW_FACTOR.subtract(BigDecimal.ONE)));
+
+        BigDecimal buyFactor;
+        BigDecimal sellFactor;
+
+        if (skew.compareTo(BigDecimal.ZERO) > 0) {
+            // 多头偏斜：base 太多 → 放宽买单价差（劝退买入），收窄卖单价差（鼓励卖出）
+            buyFactor = adjustment;
+            sellFactor = BigDecimal.ONE.divide(adjustment, 8, RoundingMode.HALF_UP);
+        } else {
+            // 空头偏斜：base 太少 → 收窄买单价差（鼓励买入），放宽卖单价差（劝退卖出）
+            buyFactor = BigDecimal.ONE.divide(adjustment, 8, RoundingMode.HALF_UP);
+            sellFactor = adjustment;
+        }
+
+        log.debug("InventoryTracker.getSpreadFactors: symbol={}, skew={}, buyFactor={}, sellFactor={}",
+                symbol, skew, buyFactor, sellFactor);
+
+        return new BigDecimal[]{buyFactor, sellFactor};
+    }
+
+    public BigDecimal getInventory(String symbol) {
+        return inventory.getOrDefault(symbol, BigDecimal.ZERO);
+    }
+}


### PR DESCRIPTION
## 背景

原策略使用固定价差，无库存跟踪，1万U资金在单边行情下容易仓位失衡。

## 新增内容

### 1. InventoryTracker（库存跟踪器）

跟踪每个交易对 base coin 净持仓，根据仓位偏斜自动调整买卖价差：

| 仓位状态 | 买单价差 | 卖单价差 | 效果 |
|---------|---------|---------|------|
| 多头偏斜（base 太多 >70%） | 放宽 | 收窄 | 鼓励卖出、劝退买入 |
| 空头偏斜（base 太少 <30%） | 收窄 | 放宽 | 鼓励买入、劝退卖出 |
| 平衡（30%~70%） | 1.0x | 1.0x | 不调整 |

最大调整幅度：1.5倍价差。

### 2. DynamicSpreadCalculator（动态价差计算器）

基于滑动窗口（100条）+ Welford 在线算法实时计算对数收益率标准差：

- 波动率 ≤ 基准（0.05%）：价差倍数 = 1.0，不调整
- 波动率超过基准：线性映射到 [1.0, 2.0]，最大2倍价差

### 3. ProfitMarketMakingSpotStrategy 集成

```
effectiveBuySpread  = baseSpread × volatilityMultiplier × buyInventoryFactor
effectiveSellSpread = baseSpread × volatilityMultiplier × sellInventoryFactor
```

### 4. 新增配置项

```properties
# application.properties
market.making.total-capital=10000   # 总资本（USDT），默认10000
```

## 数据流

```
BookTicker 事件
    → DynamicSpreadCalculator.updatePrice()  # 更新波动率
    → InventoryTracker.getSpreadFactors()    # 获取库存调整因子
    → 计算 effectiveBuySpread / effectiveSellSpread
    → 下单

订单成交事件
    → InventoryTracker.onOrderFilled()       # 更新持仓
```